### PR TITLE
Use MyST-parser for markdown

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -21,7 +21,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-from recommonmark.parser import CommonMarkParser
 
 # -- General configuration ------------------------------------------------
 
@@ -32,7 +31,7 @@ from recommonmark.parser import CommonMarkParser
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.mathjax']
+extensions = ['myst_parser', 'sphinx.ext.mathjax']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -41,10 +40,6 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 #
 source_suffix = ['.rst', '.md']
-
-source_parsers = {
-    '.md': CommonMarkParser,
-}
 
 # The master toctree document.
 master_doc = 'index'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 sphinx
 sphinx_rtd_theme
-recommonmark>=0.5.0
-commonmark>=0.8.0
+myst-parser


### PR DESCRIPTION
Recommonmark now become deprecated and unmaintained.
MyST-parser is recommended for a successor.

resolve #5 

Signed-off-by: Hiroshi Miura <miurahr@linux.com>